### PR TITLE
Fix error on fetch rules after pause

### DIFF
--- a/src/usr/local/www/status_logs_filter_dynamic.php
+++ b/src/usr/local/www/status_logs_filter_dynamic.php
@@ -225,10 +225,6 @@ function fetch_new_rules() {
 }
 
 function fetch_new_rules_callback(callback_data) {
-	if (isPaused) {
-		return;
-	}
-
 	var data_split;
 	var new_data_to_add = Array();
 	var data = callback_data.content;


### PR DESCRIPTION
fetch new rules again when uncheck the pause checkbox.
